### PR TITLE
Harden auth surface: rate-limit, CSRF, XSS, Sentry-tunnel, PII

### DIFF
--- a/__tests__/test_security.ts
+++ b/__tests__/test_security.ts
@@ -1,0 +1,52 @@
+import request from "supertest";
+
+import { app } from "../src/app";
+import { prismaMock } from "../src/singleton";
+
+describe("XSS in /o/oauth2/auth login_hint", () => {
+  // The express-validator isEmail() check is the first line of defense — a
+  // payload like `"><script>` won't get past it. But isEmail permits HTML
+  // special characters in the local part (`&`, `'`), so escaping the rendered
+  // value is still required.
+  test("html-escapes special characters in a valid email login_hint", async () => {
+    const payload = `a&b'c@example.com`;
+    const response = await request(app)
+      .get(`/o/oauth2/auth`)
+      .query({ login_hint: payload });
+
+    expect(response.status).toEqual(200);
+    expect(response.text).not.toContain(payload);
+    expect(response.text).toContain("a&amp;b&#39;c@example.com");
+  });
+});
+
+describe("CSRF on /logout", () => {
+  test("rejects GET", async () => {
+    const response = await request(app).get("/logout");
+    expect(response.status).toEqual(404);
+  });
+
+  test("accepts POST", async () => {
+    const response = await request(app).post("/logout");
+    expect(response.status).toEqual(200);
+  });
+});
+
+describe("Rate limit on /api/v1/login/request-magic", () => {
+  test("returns 429 after the per-IP burst is exhausted", async () => {
+    // findFirst returns null for an unknown email; handler still returns 200
+    // before the lookup, but rate-limit middleware runs first.
+    prismaMock.user.findFirst.mockResolvedValue(null);
+
+    const url = "/api/v1/login/request-magic";
+    // Per-IP limit is 20/15min. Send 21 requests; the 21st must be 429.
+    let lastStatus = 0;
+    for (let i = 0; i < 21; i++) {
+      const res = await request(app)
+        .post(url)
+        .send({ email: `user${i}@example.com` });
+      lastStatus = res.status;
+    }
+    expect(lastStatus).toEqual(429);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "dayjs": "^1.11.10",
         "dotenv": "^16.3.1",
         "envalid": "^8.1.0",
+        "escape-html": "^1.0.3",
         "express": "^4.21.2",
         "express-jwt": "^8.4.1",
         "express-rate-limit": "^8.5.2",
@@ -34,6 +35,7 @@
       "devDependencies": {
         "@types/cookie-session": "^2.0.49",
         "@types/cors": "^2.8.17",
+        "@types/escape-html": "^1.0.4",
         "@types/express": "^4.17.21",
         "@types/jest": "^28.1.8",
         "@types/jsbn": "^1.2.33",
@@ -1383,6 +1385,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/escape-html": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/escape-html/-/escape-html-1.0.4.tgz",
+      "integrity": "sha512-qZ72SFTgUAZ5a7Tj6kf2SHLetiH5S6f8G5frB2SPQ3EyF02kxdyBFf4Tz4banE3xCgGnKgWLt//a6VuYHKYJTg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "4.17.21",
@@ -2816,7 +2825,8 @@
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "2.0.0",
@@ -7991,6 +8001,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/escape-html": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/escape-html/-/escape-html-1.0.4.tgz",
+      "integrity": "sha512-qZ72SFTgUAZ5a7Tj6kf2SHLetiH5S6f8G5frB2SPQ3EyF02kxdyBFf4Tz4banE3xCgGnKgWLt//a6VuYHKYJTg==",
+      "dev": true
     },
     "@types/express": {
       "version": "4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "envalid": "^8.1.0",
         "express": "^4.21.2",
         "express-jwt": "^8.4.1",
+        "express-rate-limit": "^8.5.2",
         "express-validator": "^7.0.1",
         "ip-cidr": "^3.1.0",
         "jsonwebtoken": "^9.0.2",
@@ -2982,6 +2983,33 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/express-unless": {
@@ -9205,6 +9233,21 @@
         "@types/jsonwebtoken": "^9",
         "express-unless": "^2.1.3",
         "jsonwebtoken": "^9.0.0"
+      }
+    },
+    "express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "requires": {
+        "ip-address": "^10.2.0"
+      },
+      "dependencies": {
+        "ip-address": {
+          "version": "10.2.0",
+          "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+          "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="
+        }
       }
     },
     "express-unless": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "envalid": "^8.1.0",
     "express": "^4.21.2",
     "express-jwt": "^8.4.1",
+    "express-rate-limit": "^8.5.2",
     "express-validator": "^7.0.1",
     "ip-cidr": "^3.1.0",
     "jsonwebtoken": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "dayjs": "^1.11.10",
     "dotenv": "^16.3.1",
     "envalid": "^8.1.0",
+    "escape-html": "^1.0.3",
     "express": "^4.21.2",
     "express-jwt": "^8.4.1",
     "express-rate-limit": "^8.5.2",
@@ -51,6 +52,7 @@
   "devDependencies": {
     "@types/cookie-session": "^2.0.49",
     "@types/cors": "^2.8.17",
+    "@types/escape-html": "^1.0.4",
     "@types/express": "^4.17.21",
     "@types/jest": "^28.1.8",
     "@types/jsbn": "^1.2.33",

--- a/src/app.ts
+++ b/src/app.ts
@@ -25,6 +25,7 @@ import {
 import cookieSession from "cookie-session";
 import crypto from "crypto";
 import nocache from "nocache";
+import escapeHtml from "escape-html";
 import rateLimit from "express-rate-limit";
 
 import sentryTunnelHandler from "./sentry-tunnel";
@@ -97,16 +98,6 @@ if (!fs.existsSync(transparentGifPath)) {
 const GMAIL_ORIGIN: string = "https://mail.google.com";
 
 const JWT_ALGORITHM = "HS256";
-
-const HTML_ESCAPES: Record<string, string> = {
-  "&": "&amp;",
-  "<": "&lt;",
-  ">": "&gt;",
-  '"': "&quot;",
-  "'": "&#39;",
-};
-const escapeHtml = (value: string): string =>
-  value.replace(/[&<>"']/g, (ch) => HTML_ESCAPES[ch]);
 
 // -------------------------------------------------
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -25,6 +25,7 @@ import {
 import cookieSession from "cookie-session";
 import crypto from "crypto";
 import nocache from "nocache";
+import rateLimit from "express-rate-limit";
 
 import sentryTunnelHandler from "./sentry-tunnel";
 import env from "./settings";
@@ -96,6 +97,16 @@ if (!fs.existsSync(transparentGifPath)) {
 const GMAIL_ORIGIN: string = "https://mail.google.com";
 
 const JWT_ALGORITHM = "HS256";
+
+const HTML_ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+const escapeHtml = (value: string): string =>
+  value.replace(/[&<>"']/g, (ch) => HTML_ESCAPES[ch]);
 
 // -------------------------------------------------
 
@@ -562,11 +573,11 @@ app.get(
   },
 );
 
-// this logouts from everything
-// TODO(cancan101): POST + csrf token (?)
-app.get("/logout", (req: Request, res: Response): void => {
+// this logouts from everything. POST-only so a third-party page cannot trigger
+// it via an <img>/link CSRF; cookie-session uses sameSite=lax so a cross-site
+// form POST will not carry the session cookie either.
+app.post("/logout", (req: Request, res: Response): void => {
   req.session = null;
-  // <script>setTimeout(function() { top.window.close() }, 1);</script>
   res.status(200).send("You are logged out. You may close this window.");
 });
 
@@ -576,11 +587,32 @@ app.get("/logged-in", (req: Request, res: Response): void => {
 });
 
 const ROUTE_LOGIN_REQUEST_MAGIC = "/api/v1/login/request-magic";
+
+// Rate limit by IP first (cheap, runs before we parse the body), then by email
+// so a single address can't be spammed with magic links from many IPs.
+const requestMagicIpLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 20,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+});
+const requestMagicEmailLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  limit: 5,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  // Skip ensures we only reach keyGenerator when email is a string.
+  skip: (req) => typeof req.body?.email !== "string",
+  keyGenerator: (req) => (req.body.email as string).toLowerCase(),
+});
+
 app.options(ROUTE_LOGIN_REQUEST_MAGIC, corsMiddleware);
 app.post(
   ROUTE_LOGIN_REQUEST_MAGIC,
   corsMiddleware,
+  requestMagicIpLimiter,
   express.urlencoded({ extended: false }),
+  requestMagicEmailLimiter,
   body("email").isString().isEmail({ domain_specific_validation: true }),
   async (req: Request, res: Response): Promise<void> => {
     const errors = validationResult(req);
@@ -625,8 +657,6 @@ app.post(
       })
       .subject("Email Tracker")
       .text(`Login using: ${loginUrl}`);
-
-    console.log("loginUrl:", email, loginUrl);
 
     try {
       // TODO(cancan101): option to mock this (merge with log above)
@@ -858,10 +888,11 @@ app.get(
     );
 
     if (login_hint_user === undefined) {
+      const safeLoginHint = escapeHtml(login_hint);
       const errorContents =
-        `You are not currently logged in as: ${login_hint}` +
+        `You are not currently logged in as: ${safeLoginHint}` +
         `<form enctype="application/x-www-form-urlencoded" method="post" action="${ROUTE_LOGIN_REQUEST_MAGIC}">` +
-        `<input type="hidden" name="email" value="${login_hint}">` +
+        `<input type="hidden" name="email" value="${safeLoginHint}">` +
         `<input type="submit" value="Login">` +
         `</form>`;
       response.send(errorContents);

--- a/src/sentry-tunnel.ts
+++ b/src/sentry-tunnel.ts
@@ -45,7 +45,7 @@ const sentryTunnelHandler = async (
       method: "POST",
       body: envelope,
     });
-    res.json(response.json());
+    res.json(await response.json());
     return;
   } catch (e) {
     Sentry.captureException(e);


### PR DESCRIPTION
## Summary

Five fixes to the authentication / OAuth surface, all in one change because they are small and overlap in test setup:

- **Rate limit `POST /api/v1/login/request-magic`** — per-IP (20 / 15 min) and per-email (5 / hr). Previously unbounded, allowing anyone to spam magic-link emails to arbitrary addresses and run up SMTP2GO cost.
- **CSRF on `/logout`** — converted from `GET` to `POST`. The old endpoint could be triggered by any link or `<img src>` an attacker got the user to load. The codebase already had a `TODO(cancan101): POST + csrf token (?)` on this line. Cookie-session is `sameSite: "lax"`, so cross-site form POSTs do not carry the session cookie — POST-only is sufficient defense without introducing a token store. The extension does not call `/logout`, so no extension change is needed.
- **XSS in `/o/oauth2/auth`** — `login_hint` was interpolated unescaped into the HTML attribute of a hidden form input. `isEmail()` is the first line of defense and blocks `"`/`<`/`>`, but the local part of a valid email may still contain `&` and `'`, so escaping is required.
- **Sentry tunnel handler** — `res.json(response.json())` passed an unresolved Promise to `res.json()`, silently returning `{}` and dropping every tunneled extension event. Now awaits the body.
- **Stop logging PII / credentials** — removed `console.log("loginUrl:", email, loginUrl)`. The URL is a bearer credential good for 24h (default), and the email is PII; neither belongs in request logs.

## Test plan

`__tests__/test_security.ts` covers each behavioral change:

- [x] XSS: a valid email with `&` and `'` in the local part renders as `a&amp;b&#39;c@example.com`
- [x] CSRF: `GET /logout` returns 404, `POST /logout` returns 200
- [x] Rate limit: 21st request from the same IP within the window returns 429
- [x] Existing view/tracker tests still pass (6/6)
- [x] `npm run build` clean
- [x] `npx prettier --check .` clean

## Out of scope

The audit also flagged stateless OAuth authorization codes (`revokeAuthorizationCode` is a no-op), thin test coverage on the pixel handler, `console.log` → structured logging, and the in-app self-load filter that should be pushed into SQL. Those are listed for a follow-up and intentionally left out of this PR to keep the diff reviewable.

https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K)_