### PR TITLE
Back OAuth authorization codes with Postgres

### DIFF
--- a/__tests__/test_oauth_codes.ts
+++ b/__tests__/test_oauth_codes.ts
@@ -1,0 +1,115 @@
+import { OAuthServerModel } from "../src/app";
+import { prismaMock } from "../src/singleton";
+
+const baseCode = {
+  code: "abc-uuid-code",
+  clientId: "client-1",
+  userId: "71cf7000-cf96-47b4-bc9f-bf36f486a088",
+  redirectUri: "https://example.com/cb",
+  scope: null,
+  expiresAt: new Date(Date.now() + 60_000),
+  createdAt: new Date(),
+  consumedAt: null,
+};
+
+describe("OAuthServerModel.getAuthorizationCode", () => {
+  test("returns the code when it is valid", async () => {
+    prismaMock.authorizationCode.findUnique.mockResolvedValue(baseCode);
+
+    const result = await OAuthServerModel.getAuthorizationCode("abc-uuid-code");
+    if (!result) throw new Error("expected a truthy AuthorizationCode");
+    expect(result.authorizationCode).toEqual("abc-uuid-code");
+    expect(result.user).toEqual({ id: baseCode.userId });
+    expect(result.client.id).toEqual("client-1");
+  });
+
+  test("throws when the code is unknown", async () => {
+    prismaMock.authorizationCode.findUnique.mockResolvedValue(null);
+
+    await expect(OAuthServerModel.getAuthorizationCode("nope")).rejects.toThrow(
+      /invalid/,
+    );
+  });
+
+  test("throws when the code has already been consumed", async () => {
+    prismaMock.authorizationCode.findUnique.mockResolvedValue({
+      ...baseCode,
+      consumedAt: new Date(),
+    });
+
+    await expect(
+      OAuthServerModel.getAuthorizationCode("abc-uuid-code"),
+    ).rejects.toThrow(/already used/);
+  });
+
+  test("throws when the code is past expiry", async () => {
+    prismaMock.authorizationCode.findUnique.mockResolvedValue({
+      ...baseCode,
+      expiresAt: new Date(Date.now() - 60_000),
+    });
+
+    await expect(
+      OAuthServerModel.getAuthorizationCode("abc-uuid-code"),
+    ).rejects.toThrow(/expired/);
+  });
+});
+
+describe("OAuthServerModel.revokeAuthorizationCode", () => {
+  test("returns true when exactly one row is marked consumed", async () => {
+    prismaMock.authorizationCode.updateMany.mockResolvedValue({ count: 1 });
+
+    const ok = await OAuthServerModel.revokeAuthorizationCode({
+      authorizationCode: "abc",
+      expiresAt: new Date(),
+      redirectUri: "x",
+      client: { id: "c", grants: [] },
+      user: { id: "u" },
+    });
+    expect(ok).toBe(true);
+
+    // Confirm it filters by consumedAt: null so a concurrent revoke can't
+    // double-mark.
+    expect(prismaMock.authorizationCode.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ consumedAt: null }),
+      }),
+    );
+  });
+
+  test("returns false when no eligible row exists", async () => {
+    prismaMock.authorizationCode.updateMany.mockResolvedValue({ count: 0 });
+
+    const ok = await OAuthServerModel.revokeAuthorizationCode({
+      authorizationCode: "abc",
+      expiresAt: new Date(),
+      redirectUri: "x",
+      client: { id: "c", grants: [] },
+      user: { id: "u" },
+    });
+    expect(ok).toBe(false);
+  });
+});
+
+describe("OAuthServerModel.saveAuthorizationCode", () => {
+  test("inserts the code into the database and echoes it back", async () => {
+    prismaMock.authorizationCode.create.mockResolvedValue(baseCode);
+
+    const result = await OAuthServerModel.saveAuthorizationCode(
+      {
+        authorizationCode: "(library-supplied-but-ignored)",
+        expiresAt: new Date(Date.now() + 60_000),
+        redirectUri: "https://example.com/cb",
+      },
+      { id: "client-1", grants: ["authorization_code"] },
+      { id: "71cf7000-cf96-47b4-bc9f-bf36f486a088" },
+    );
+
+    expect(prismaMock.authorizationCode.create).toHaveBeenCalledTimes(1);
+    // The handler mints its own opaque code; we don't pass through the
+    // library's input value.
+    if (!result) throw new Error("expected a truthy AuthorizationCode");
+    expect(result.authorizationCode).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+  });
+});

--- a/prisma/migrations/20260517172646_authorization_code/migration.sql
+++ b/prisma/migrations/20260517172646_authorization_code/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "AuthorizationCode" (
+    "code" VARCHAR NOT NULL,
+    "clientId" VARCHAR NOT NULL,
+    "userId" UUID NOT NULL,
+    "redirectUri" VARCHAR NOT NULL,
+    "scope" VARCHAR,
+    "expiresAt" TIMESTAMPTZ(6) NOT NULL,
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "consumedAt" TIMESTAMPTZ(6),
+
+    CONSTRAINT "AuthorizationCode_pkey" PRIMARY KEY ("code")
+);
+
+-- CreateIndex
+CREATE INDEX "AuthorizationCode_expiresAt_idx" ON "AuthorizationCode"("expiresAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,3 +57,16 @@ model MagicLinkToken {
   usedAt    DateTime? @db.Timestamptz(6)
   user      User      @relation(fields: [userId], references: [id])
 }
+
+model AuthorizationCode {
+  code        String    @id @db.VarChar
+  clientId    String    @db.VarChar
+  userId      String    @db.Uuid
+  redirectUri String    @db.VarChar
+  scope       String?   @db.VarChar
+  expiresAt   DateTime  @db.Timestamptz(6)
+  createdAt   DateTime  @default(now()) @db.Timestamptz(6)
+  consumedAt  DateTime? @db.Timestamptz(6)
+
+  @@index([expiresAt])
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -802,56 +802,75 @@ const OAuthServerModel: AuthorizationCodeModel = {
     };
   },
   generateAccessToken: async (client, user, scope) => {
-    return user.accessToken;
+    // Mint the token here instead of pulling one off the user object that
+    // the authorize step pulled out of the session. With DB-backed codes
+    // only the userId is round-tripped, and this also means the JWT is
+    // freshly issued at token-exchange time rather than reused from login.
+    const { accessToken } = await getAccessToken(String(user.id));
+    return accessToken;
   },
   getAuthorizationCode: async (
     authorizationCode,
   ): Promise<AuthorizationCode> => {
-    // here we just parse the jwt that send out
-    // we should verify
-    const data = jsonwebtoken.decode(authorizationCode);
-    if (data === null || typeof data === "string") {
-      throw Error();
+    // Look the code up in Postgres. Reject if it's missing, already used,
+    // or expired. Returning anything other than a valid code makes the
+    // node-oauth library refuse the token exchange.
+    const row = await prisma.authorizationCode.findUnique({
+      where: { code: authorizationCode },
+    });
+    if (row === null) {
+      throw new Error("invalid authorization code");
     }
-    const { client, user, expiresAt: expiresAtNum, redirectUri } = data;
-
+    if (row.consumedAt !== null) {
+      throw new Error("authorization code already used");
+    }
+    if (row.expiresAt < new Date()) {
+      throw new Error("authorization code expired");
+    }
     return {
-      authorizationCode,
-      client,
-      user,
-      expiresAt: new Date(expiresAtNum),
-      redirectUri,
+      authorizationCode: row.code,
+      expiresAt: row.expiresAt,
+      redirectUri: row.redirectUri,
+      scope: row.scope ?? undefined,
+      // node-oauth only reads `client.id` and `user.id` after this point;
+      // grants is required on the client shape per its types.
+      client: { id: row.clientId, grants: ["authorization_code"] },
+      user: { id: row.userId },
     };
   },
-  revokeAuthorizationCode: async () => {
-    // we can't currently revoke as this is stateless
-    return true;
+  revokeAuthorizationCode: async (code): Promise<boolean> => {
+    // Atomic single-use: only the first revoke that finds consumedAt=null
+    // succeeds. updateMany returns a count, so concurrent token exchanges
+    // can't both win.
+    const result = await prisma.authorizationCode.updateMany({
+      where: {
+        code: code.authorizationCode,
+        consumedAt: null,
+      },
+      data: { consumedAt: new Date() },
+    });
+    return result.count === 1;
   },
   verifyScope: async (): Promise<never> => {
     //https://oauth2-server.readthedocs.io/en/latest/model/spec.html#verifyscope-accesstoken-scope-callback
     throw Error();
   },
-  // we should use a real auth code and not this BS
   saveAuthorizationCode: async (
     code,
     client,
     user,
   ): Promise<AuthorizationCode> => {
-    const authorizationCode = await jsonwebtoken.sign(
-      {
+    const authorizationCode = crypto.randomUUID();
+    await prisma.authorizationCode.create({
+      data: {
+        code: authorizationCode,
+        clientId: String(client.id),
+        userId: String(user.id),
         redirectUri: code.redirectUri,
-        expiresAt: code.expiresAt.getTime(),
-        client,
-        user,
+        expiresAt: code.expiresAt,
+        scope: typeof code.scope === "string" ? code.scope : null,
       },
-      env.JWT_ACCESS_TOKEN_SECRET,
-      {
-        algorithm: JWT_ALGORITHM,
-        // Should we track any of these?
-        // expiresIn,
-        // subject,
-      },
-    );
+    });
     return {
       ...code,
       authorizationCode,
@@ -949,4 +968,4 @@ app.use(
 
 // -------------------------------------------------
 
-export { app, getAccessToken };
+export { app, getAccessToken, OAuthServerModel };


### PR DESCRIPTION
## Summary

Previously authorization codes were stateless. `saveAuthorizationCode` emitted a signed JWT, `getAuthorizationCode` decoded it **without verifying the signature**, and `revokeAuthorizationCode` was a no-op with the explicit comment "we can't currently revoke as this is stateless." That means:

- A consumed code could be replayed.
- A "revoke access" UI would have no real effect.
- The signature check was missing on the path that consumed the code.

This PR adds an `AuthorizationCode` table and rewrites all three model methods to use it:

- **`saveAuthorizationCode`** — mints an opaque `randomUUID()`, inserts a row, returns the code. No JWT in this slot anymore.
- **`getAuthorizationCode`** — `SELECT` by code, reject if missing, already consumed, or past expiry.
- **`revokeAuthorizationCode`** — atomic `updateMany WHERE consumedAt IS NULL`, so concurrent token exchanges can't both win. Single-use is enforced at the DB level, not application code.

## Knock-on change: `generateAccessToken`

The old code returned `user.accessToken` from the in-memory user object that the authorize step pulled out of the session. With DB-backed codes we only round-trip the `userId`, so this now calls the existing `getAccessToken(userId)` helper to mint the JWT at exchange time. Net positive — the access token's lifetime starts at exchange, not at login.

## Migration

`prisma/migrations/20260517172646_authorization_code/migration.sql` adds the table and an index on `expiresAt` (handy for cleanup jobs). Run via the existing `release: npx prisma migrate deploy` step in `Procfile`.

## Test plan

`__tests__/test_oauth_codes.ts` covers:

- [x] Happy path: a valid code is returned with correct user/client shape
- [x] Unknown code → throws
- [x] Already-consumed code → throws
- [x] Expired code → throws
- [x] `revokeAuthorizationCode` returns `true` when `updateMany` count is 1
- [x] Returns `false` when count is 0 (already consumed or missing)
- [x] `updateMany` filters on `consumedAt: null` (single-use guarantee)
- [x] `saveAuthorizationCode` mints an opaque UUID rather than passing through the library's placeholder input

Plus all existing tests pass unchanged (10/10 → 17/17).

## Not covered by this PR (worth a follow-up)

- A cleanup job that deletes / archives codes past `expiresAt + grace`. The index on `expiresAt` is in place.
- The `getClient` flow still validates client secret length non-constant-time before the `timingSafeEqual` call — separate issue, separate PR.

## Independent of other PRs

Branches off `main` (post #712 merge). The other open PRs (#713 observability, #714 zod) don't touch the OAuth model, so no conflicts are expected if this lands in any order.

https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K)_