### PR TITLE
Restore GET /logout for Gmail add-on; add OAuth integration test

### DIFF
--- a/__tests__/test_oauth_integration.ts
+++ b/__tests__/test_oauth_integration.ts
@@ -1,0 +1,74 @@
+import request from "supertest";
+import { randomUUID } from "crypto";
+
+import { app } from "../src/app";
+import { prismaMock } from "../src/singleton";
+
+// End-to-end check that the magic-login flow plants `id` into the
+// cookie-session, and that a subsequent /o/oauth2/auth round-trip reaches
+// saveAuthorizationCode with that id intact.
+
+describe("magic-login → OAuth integration", () => {
+  test("session minted by /magic-login carries id into saveAuthorizationCode", async () => {
+    const userId = "71cf7000-cf96-47b4-bc9f-bf36f486a088";
+    const userEmail = "alice@example.com";
+    const token = randomUUID();
+
+    // Mock the magic-link token lookup + mark-used + access-token mint.
+    prismaMock.magicLinkToken.findFirst.mockResolvedValue({
+      id: "tok-row-id",
+      createdAt: new Date(),
+      token,
+      userId,
+      expiresAt: new Date(Date.now() + 60_000),
+      usedAt: null,
+      // @ts-expect-error include shape
+      user: { email: userEmail, slug: "slug-uuid" },
+    });
+    prismaMock.magicLinkToken.update.mockResolvedValue({} as any);
+
+    // Mock authorization-code insert so we can inspect what would be written.
+    prismaMock.authorizationCode.create.mockResolvedValue({
+      code: "x",
+      clientId: "client-1",
+      userId,
+      redirectUri: "https://test.local",
+      scope: [],
+      expiresAt: new Date(Date.now() + 60_000),
+      createdAt: new Date(),
+      consumedAt: null,
+    });
+
+    const agent = request.agent(app);
+
+    // 1. /magic-login plants the session
+    const loginRes = await agent.get(`/magic-login?token=${token}`);
+    expect(loginRes.status).toEqual(200);
+    expect(loginRes.headers["set-cookie"]).toBeDefined();
+
+    // 2. /o/oauth2/auth with the session and matching login_hint
+    const authRes = await agent.get("/o/oauth2/auth").query({
+      login_hint: userEmail,
+      response_type: "code",
+      client_id: process.env.GMAIL_ADDON_CLIENT_ID ?? "CLIENT_ID",
+      redirect_uri:
+        process.env.GMAIL_ADDON_REDIRECT_URI ?? "https://test.local",
+      state: "xyz",
+    });
+
+    // The oauth library will redirect (302) with the code on success, or
+    // 4xx/5xx if something is wrong. We want to assert that *if* the model
+    // was called, it received the real UUID — not "undefined".
+    if (prismaMock.authorizationCode.create.mock.calls.length > 0) {
+      const writtenData =
+        prismaMock.authorizationCode.create.mock.calls[0][0].data;
+      expect(writtenData.userId).toEqual(userId);
+      expect(writtenData.userId).not.toEqual("undefined");
+    } else {
+      // If create wasn't called, surface why for debugging.
+      throw new Error(
+        `saveAuthorizationCode was not reached. /o/oauth2/auth status=${authRes.status} body=${JSON.stringify(authRes.body)} text=${authRes.text.slice(0, 500)}`,
+      );
+    }
+  });
+});

--- a/__tests__/test_security.ts
+++ b/__tests__/test_security.ts
@@ -26,10 +26,13 @@ describe("XSS in /o/oauth2/auth login_hint", () => {
   });
 });
 
-describe("CSRF on /logout", () => {
-  test("rejects GET", async () => {
+describe("/logout", () => {
+  // Both verbs are accepted: POST is the preferred path for browser clients,
+  // GET is required by the Gmail Apps Script add-on whose CardService button
+  // opens the URL via a top-level navigation in an overlay.
+  test("accepts GET (Apps Script add-on path)", async () => {
     const response = await request(app).get("/logout");
-    expect(response.status).toEqual(404);
+    expect(response.status).toEqual(200);
   });
 
   test("accepts POST", async () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -592,13 +592,17 @@ app.get("/magic-login", async (req: Request, res: Response): Promise<void> => {
   return;
 });
 
-// this logouts from everything. POST-only so a third-party page cannot trigger
-// it via an <img>/link CSRF; cookie-session uses sameSite=lax so a cross-site
-// form POST will not carry the session cookie either.
-app.post("/logout", (req: Request, res: Response): void => {
+// Logout destroys the session. We accept both GET and POST because the Gmail
+// Apps Script add-on uses CardService.newOpenLink (a top-level GET) to open
+// /logout in an overlay, and there's no way to make Apps Script issue a POST
+// for that UX. The residual CSRF risk on the GET is bounded: the worst an
+// attacker can do is log a user out, which is annoying but recoverable.
+const logoutHandler = (req: Request, res: Response): void => {
   req.session = null;
   res.status(200).send("You are logged out. You may close this window.");
-});
+};
+app.get("/logout", logoutHandler);
+app.post("/logout", logoutHandler);
 
 app.get("/logged-in", (req: Request, res: Response): void => {
   res.status(200).send("You are logged in. You may close this window.");


### PR DESCRIPTION
## Summary

Two related fixes.

### Restore `GET /logout`

PR #712 changed `/logout` to POST-only. That silently broke the Gmail Apps Script add-on, which logs out via a `CardService.newOpenLink()` button — a top-level GET navigation in an overlay. Apps Script has no way to issue a POST for that UX, so accepting both verbs is the only path that keeps the button working.

The original concern was CSRF on a GET logout (``&lt;img src="/logout"&gt;``). The impact is "user gets logged out" — annoying, recoverable in seconds, no data exposure. Trading the residual GET-CSRF risk for a working production button is the right call. The comment in the source records the rationale so this doesn't regress again.

### `test_oauth_integration.ts`

The OAuth test gap that allowed #715's `user.id` regression in. This test walks the full flow:

1. `request.agent(app)` — supertest with cookie persistence.
2. `GET /magic-login?token=...` — Prisma mock returns a token row, the handler writes `session.users` to the signed cookie.
3. `GET /o/oauth2/auth?login_hint=...&...` — re-uses the cookie, exercises the full `oauth.authorize()` middleware chain through `@node-oauth`.
4. Asserts `prismaMock.authorizationCode.create` was called with `userId` equal to the real UUID, **not** the string `"undefined"`.

Confirms the code currently on `main` (post-#717) actually works end-to-end.

## Test plan

- [x] 27/27 tests pass (was 26; the integration test adds one)
- [x] `npm run build` clean
- [x] `npx prettier --check .` clean
- [x] Existing `/logout` POST behavior unchanged

https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K)_