### PR TITLE
Require minimum length for JWT and cookie secrets

### DIFF
--- a/__tests__/testing.env
+++ b/__tests__/testing.env
@@ -1,6 +1,6 @@
-COOKIE_SESSION_SECRET=asdf
+COOKIE_SESSION_SECRET=test-cookie-session-secret-asdfasdfasdf
 GMAIL_ADDON_REDIRECT_URI=https://test.local
-JWT_ACCESS_TOKEN_SECRET=qwerty
+JWT_ACCESS_TOKEN_SECRET=test-jwt-access-token-secret-qwertyqwerty
 MAGIC_LINK_FROM_EMAIL=test@test.com
 PORT=8000
 SMTP2GO_API_KEY=api-DEADBEEF

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,13 +1,36 @@
 import dotenv from "dotenv";
-import { cleanEnv, str, email, port, num, url, host, bool } from "envalid";
+import {
+  cleanEnv,
+  str,
+  email,
+  port,
+  num,
+  url,
+  host,
+  bool,
+  makeValidator,
+} from "envalid";
 
 // -------------------------------------------------
 
 dotenv.config();
 
+// Reject short secrets at boot so a misconfigured deploy fails fast instead
+// of running with cryptographically weak HS256 / cookie-signing keys. 32 chars
+// is the minimum to give HMAC-SHA256 a full block of entropy.
+const SECRET_MIN_LENGTH = 32;
+const secret = makeValidator<string>((value) => {
+  if (typeof value !== "string" || value.length < SECRET_MIN_LENGTH) {
+    throw new Error(
+      `expected at least ${SECRET_MIN_LENGTH} characters, got ${typeof value === "string" ? value.length : typeof value}`,
+    );
+  }
+  return value;
+});
+
 const env = cleanEnv(process.env, {
-  JWT_ACCESS_TOKEN_SECRET: str(),
-  COOKIE_SESSION_SECRET: str(),
+  JWT_ACCESS_TOKEN_SECRET: secret(),
+  COOKIE_SESSION_SECRET: secret(),
   COOKIE_SESSION_SECURE: bool({ default: true, devDefault: false }),
   SMTP2GO_API_KEY: str(),
   PORT: port(),


### PR DESCRIPTION
## Summary

`JWT_ACCESS_TOKEN_SECRET` and `COOKIE_SESSION_SECRET` previously used bare `str()` so a 4-char value would pass validation at boot. HS256 with a short secret is cryptographically weak; cookie-session signed with a short key is brute-forceable.

Adds an envalid `makeValidator` that requires ≥32 chars. A deploy with a too-short secret now fails at boot with a clear message instead of running with weak keys.

Test env values in `__tests__/testing.env` were lengthened to satisfy the new floor.

## Test plan

- [x] 27/27 tests pass
- [x] `npm run build` clean
- [x] `npx prettier --check .` clean

https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K)_