### PR TITLE
Graceful shutdown on SIGTERM/SIGINT

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,51 @@ import throng from "throng";
 import env from "./settings";
 import { app } from "./app";
 import logger from "./logger";
+import prisma from "./client";
+
+// Heroku sends SIGTERM and waits up to 30s for the process to exit. Without
+// a handler, in-flight requests are dropped at deploy time. Close the HTTP
+// server (stops accepting new connections, waits for active ones to finish)
+// and disconnect Prisma so its pool drains cleanly.
+const SHUTDOWN_TIMEOUT_MS = 25_000;
 
 function start() {
-  app.listen(env.PORT, async () => {
+  const server = app.listen(env.PORT, async () => {
     logger.info({ port: env.PORT }, "Server listening");
   });
+
+  let shuttingDown = false;
+  const shutdown = (signal: string) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    logger.info({ signal }, "Shutdown signal received");
+
+    // Hard exit if cleanup takes too long so we never block past the
+    // platform's kill window.
+    const killTimer = setTimeout(() => {
+      logger.error("Shutdown timed out; exiting forcefully");
+      process.exit(1);
+    }, SHUTDOWN_TIMEOUT_MS);
+    killTimer.unref();
+
+    server.close((err) => {
+      if (err) {
+        logger.error({ err }, "Error closing HTTP server");
+      }
+      prisma
+        .$disconnect()
+        .catch((dErr) =>
+          logger.error({ err: dErr }, "Error disconnecting Prisma"),
+        )
+        .finally(() => {
+          logger.info("Shutdown complete");
+          process.exit(err ? 1 : 0);
+        });
+    });
+  };
+
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  process.on("SIGINT", () => shutdown("SIGINT"));
 }
 
 logger.info({ webConcurrency: env.WEB_CONCURRENCY }, "Boot");


### PR DESCRIPTION
## Summary

`src/index.ts` previously discarded the value returned by `app.listen()` and never registered signal handlers. On every Heroku deploy (SIGTERM with a 30s grace window) in-flight requests were dropped.

This PR:

- Captures the listening server.
- Registers `SIGTERM` and `SIGINT` handlers.
- Closes the HTTP server (stops accepting new connections, waits for active ones to finish).
- Disconnects the Prisma client so its pool drains cleanly.
- Falls through to a forceful `process.exit(1)` after 25s so we never block past Heroku's kill window. The timer is `unref()`-ed so it doesn't keep the loop alive on its own.

## Test plan

- [x] 27/27 tests pass (no behavior change in tests)
- [x] `npm run build` clean

Hard to unit-test cleanly without a child-process harness; the shape of the code is small and self-contained.

https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K)_