### PR TITLE
Add /healthz endpoint with DB probe

### DIFF
--- a/__tests__/test_healthz.ts
+++ b/__tests__/test_healthz.ts
@@ -1,0 +1,34 @@
+import request from "supertest";
+
+import { app } from "../src/app";
+import { prismaMock } from "../src/singleton";
+
+describe("/healthz", () => {
+  test("returns 200 with status ok when DB probe succeeds", async () => {
+    prismaMock.$queryRaw.mockResolvedValue([{ "?column?": 1 }]);
+
+    const response = await request(app).get("/healthz");
+
+    expect(response.status).toEqual(200);
+    expect(response.body).toEqual({ status: "ok" });
+  });
+
+  test("returns 503 when DB probe fails", async () => {
+    prismaMock.$queryRaw.mockRejectedValue(new Error("connection refused"));
+
+    const response = await request(app).get("/healthz");
+
+    expect(response.status).toEqual(503);
+    expect(response.body).toEqual(
+      expect.objectContaining({ status: "degraded" }),
+    );
+  });
+});
+
+describe("/ping", () => {
+  test("returns 200 without touching the DB (liveness only)", async () => {
+    const response = await request(app).get("/ping");
+    expect(response.status).toEqual(200);
+    expect(prismaMock.$queryRaw).not.toHaveBeenCalled();
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -762,9 +762,23 @@ app.post(
   },
 );
 
-// Probably not needed long term
+// Cheap liveness probe — does not touch the DB. Kept for backwards
+// compatibility; new platform health checks should target /healthz.
 app.get("/ping", (req: Request, res: Response): void => {
   res.status(200).send("");
+});
+
+// Readiness probe that verifies the process can reach Postgres. Returns 503
+// if the DB is unreachable so the platform pulls this dyno out of rotation
+// instead of routing traffic to a broken instance.
+app.get("/healthz", async (req: Request, res: Response): Promise<void> => {
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    res.status(200).json({ status: "ok" });
+  } catch (err) {
+    req.log.warn({ err }, "Healthz DB probe failed");
+    res.status(503).json({ status: "degraded", reason: "database" });
+  }
 });
 
 app.options("/api/v1/stunnel", corsMiddleware);


### PR DESCRIPTION
## Summary

`/ping` returned 200 even if Postgres was unreachable, so a broken dyno would silently stay in rotation. Adds `/healthz` that runs `SELECT 1` through Prisma and returns 503 on DB failure so the platform pulls the dyno.

`/ping` is kept as-is for backwards compatibility and as a cheap *liveness* probe (the process is responsive even if the DB is down).

## Test plan

`__tests__/test_healthz.ts` covers:

- [x] 200 + `{status: "ok"}` when `$queryRaw` succeeds
- [x] 503 + `{status: "degraded"}` when it throws
- [x] `/ping` still returns 200 and does *not* touch the DB

30/30 total tests pass; build clean.

https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K)_