### PR TITLE
Add cleanup script for expired AuthorizationCode rows

### DIFF
--- a/__tests__/test_cleanup_auth_codes.ts
+++ b/__tests__/test_cleanup_auth_codes.ts
@@ -1,0 +1,45 @@
+import { cleanupAuthCodes } from "../scripts/cleanup_auth_codes";
+
+jest.mock("@prisma/client", () => {
+  const deleteMany = jest.fn();
+  return {
+    __esModule: true,
+    PrismaClient: jest.fn().mockImplementation(() => ({
+      authorizationCode: { deleteMany },
+      $disconnect: jest.fn(),
+    })),
+    __deleteMany: deleteMany,
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { __deleteMany: deleteMany } = require("@prisma/client") as {
+  __deleteMany: jest.Mock;
+};
+
+beforeEach(() => deleteMany.mockReset());
+
+describe("cleanupAuthCodes", () => {
+  test("deletes codes whose expiresAt is older than now - graceHours", async () => {
+    deleteMany.mockResolvedValue({ count: 7 });
+
+    const before = Date.now();
+    const deleted = await cleanupAuthCodes(24);
+    const after = Date.now();
+
+    expect(deleted).toEqual(7);
+    expect(deleteMany).toHaveBeenCalledTimes(1);
+    const call = deleteMany.mock.calls[0][0];
+    const cutoff: Date = call.where.expiresAt.lt;
+    // Cutoff is now - 24h, evaluated at call time.
+    const lowerBound = before - 24 * 60 * 60 * 1000;
+    const upperBound = after - 24 * 60 * 60 * 1000;
+    expect(cutoff.getTime()).toBeGreaterThanOrEqual(lowerBound);
+    expect(cutoff.getTime()).toBeLessThanOrEqual(upperBound);
+  });
+
+  test("propagates errors from Prisma so the script exits non-zero", async () => {
+    deleteMany.mockRejectedValue(new Error("connection lost"));
+    await expect(cleanupAuthCodes(1)).rejects.toThrow(/connection lost/);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "npm run lint && npm run test:unit",
     "add-user": "ts-node --files --transpile-only  scripts/add_user.ts",
     "lookup-icloud-ip": "ts-node --files --transpile-only scripts/lookup_icloud_ip.ts",
+    "cleanup:auth-codes": "ts-node --files --transpile-only scripts/cleanup_auth_codes.ts",
     "prepare": "husky install",
     "lint": "npx prettier --check .",
     "test:unit": "jest -i"

--- a/scripts/cleanup_auth_codes.ts
+++ b/scripts/cleanup_auth_codes.ts
@@ -1,0 +1,58 @@
+import { PrismaClient } from "@prisma/client";
+const { program } = require("commander");
+
+// One-shot cleanup of the AuthorizationCode table. Designed to be invoked
+// from Heroku Scheduler (or any cron) once a day:
+//
+//   npm run cleanup:auth-codes
+//
+// Deletes rows whose expiresAt is older than a grace period (default 1 day).
+// Keeping recently-expired rows around briefly is useful for forensic logs
+// if a replayed code is reported.
+
+const prisma = new PrismaClient();
+
+async function cleanupAuthCodes(graceHours: number): Promise<number> {
+  const cutoff = new Date(Date.now() - graceHours * 60 * 60 * 1000);
+  const result = await prisma.authorizationCode.deleteMany({
+    where: { expiresAt: { lt: cutoff } },
+  });
+  return result.count;
+}
+
+program
+  .option(
+    "--grace-hours <hours>",
+    "delete codes whose expiresAt is older than now minus this many hours",
+    "24",
+  )
+  .action(async (opts: { graceHours: string }) => {
+    const graceHours = parseInt(opts.graceHours, 10);
+    if (isNaN(graceHours) || graceHours < 0) {
+      console.error(`Invalid --grace-hours: ${opts.graceHours}`);
+      process.exit(2);
+    }
+    try {
+      const deleted = await cleanupAuthCodes(graceHours);
+      console.log(
+        JSON.stringify({
+          event: "cleanup_auth_codes",
+          deleted,
+          graceHours,
+        }),
+      );
+    } catch (err) {
+      console.error(err);
+      process.exit(1);
+    } finally {
+      await prisma.$disconnect();
+    }
+  });
+
+// Only parse argv when invoked as a CLI; tests import this module and would
+// otherwise see the jest argv ("-i", etc.) and bail.
+if (require.main === module) {
+  program.parse();
+}
+
+export { cleanupAuthCodes };


### PR DESCRIPTION
## Summary

PR #715 added the `AuthorizationCode` table with an `expiresAt` index but no cleanup. Every successful OAuth login mints a row that's never deleted; over time the table grows unbounded.

Adds a one-shot script (`npm run cleanup:auth-codes`) that deletes rows whose `expiresAt` is older than `now - 24h` (configurable via `--grace-hours`). Intended for Heroku Scheduler. Keeping recently-expired rows briefly is useful for forensics if a replayed code is reported.

## Heroku Scheduler config

Manual one-time setup:

- Schedule: Every day at 00:00 UTC
- Command: `npm run cleanup:auth-codes`

## Test plan

`__tests__/test_cleanup_auth_codes.ts`:

- [x] Cutoff is computed as `now - graceHours * 3600s` at call time (verified within an upper/lower bound window).
- [x] Errors from Prisma propagate so the script exits non-zero.
- [x] 29/29 tests pass overall; build clean.

The `program.parse()` call is guarded with `require.main === module` so the function can be unit-tested without commander consuming the jest argv.

https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K)_