### PR TITLE
Accept format-valid UUIDs in userId param (loose match)

### DIFF
--- a/__tests__/test_validation.ts
+++ b/__tests__/test_validation.ts
@@ -53,4 +53,18 @@ describe("zod validation on /api/v1/views/", () => {
       .set("Authorization", `Bearer ${accessToken}`);
     expect(response.status).toEqual(400);
   });
+
+  test("accepts a format-valid UUID that doesn't satisfy RFC version bits", async () => {
+    // Pre-#714, isUUID() accepted any 8-4-4-4-12 hex string. zod's .uuid()
+    // enforces RFC version/variant bits (position 14 must be 1-8, position
+    // 19 must be 8/9/a/b). Some historical user rows have version=0 and/or
+    // variant=0, so the userId schema uses a regex to match the old loose
+    // behavior. This fixture has 0 in both positions.
+    const looseUserId = "feedface-cafe-0bad-0ddd-deadbeefcafe";
+    const { accessToken } = await getAccessToken(userId);
+    const response = await request(app)
+      .get(`/api/v1/views/?userId=${looseUserId}&limit=20`)
+      .set("Authorization", `Bearer ${accessToken}`);
+    expect(response.status).not.toEqual(400);
+  });
 });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -2,6 +2,18 @@ import { z } from "zod";
 
 const UUID = z.string().uuid();
 
+// userId can be a historical value (e.g. inserted manually via the
+// add_user script) that doesn't satisfy RFC 4122 version/variant bits but
+// is otherwise a valid 8-4-4-4-12 hex string. express-validator's old
+// isUUID() accepted these; zod's .uuid() does not. Use a regex for userId
+// only — every other UUID field in this app is minted by Prisma's
+// @default(uuid()) or randomUUID(), so strict RFC checks are correct there.
+const USER_ID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const userIdSchema = z
+  .string()
+  .regex(USER_ID_REGEX, { message: "Invalid UUID format" });
+
 // Subject and body fields are bounded so a client cannot post arbitrarily
 // large strings into the DB. 1000 chars is comfortably above any real
 // Gmail thread / subject length while keeping a sane upper bound.
@@ -22,7 +34,7 @@ export const threadParamsSchema = z.object({
 });
 
 export const viewsQuerySchema = z.object({
-  userId: UUID,
+  userId: userIdSchema,
   // Express delivers query values as strings; coerce + validate.
   limit: z.coerce.number().int().positive().optional(),
 });


### PR DESCRIPTION
## Summary

Regression from PR #714 (express-validator → zod migration). `/api/v1/views/?userId=...` now 400s for some real production values:

```
{"errors":[{"path":"userId","message":"Invalid UUID","code":"invalid_format"}]}
```

## Why

- `express-validator`'s `isUUID()` defaulted to accepting **any** 8-4-4-4-12 hex string — pure format check.
- `zod`'s `.uuid()` enforces RFC 4122 / 9562: position 14 must be a version digit (1-8), position 19 must be a variant digit (8/9/a/b).

Some historical `User.id` rows (inserted manually, e.g. via `scripts/add_user.ts`) have version/variant nibbles of 0. They're correctly formatted but not RFC-conformant; zod rejects them, express-validator didn't.

## Fix

Loosen validation **only for `userId`**. The other UUID fields (`trackId`, `trackingSlug`, `token`) are all minted by Prisma's `@default(uuid())` or `randomUUID()`, so they're guaranteed RFC-compliant and stay on strict `z.string().uuid()`.

`src/schemas.ts`:

```ts
const UUID = z.string().uuid();   // unchanged; used for trackId / trackingSlug / token

const USER_ID_REGEX =
  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
const userIdSchema = z
  .string()
  .regex(USER_ID_REGEX, { message: "Invalid UUID format" });

export const viewsQuerySchema = z.object({
  userId: userIdSchema,   // ← only place that gets the loose check
  limit: z.coerce.number().int().positive().optional(),
});
```

`userId` is the only field validated by zod in this layer — every other handler reads userId from `req.auth.sub` (the JWT subject), which doesn't go through zod.

## Test plan

- [x] New regression test in `test_validation.ts`: a synthetic UUID with version=0 and variant=0 passes validation on `/api/v1/views/` (response is not 400 — gets through to the JWT-mismatch check downstream).
- [x] All other UUID validation tests still pass on the strict path (a malformed `trackId` on `/api/v1/trackers/` still 400s).
- [x] 37/37 tests pass overall.
- [x] `npm run build` clean.

https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K